### PR TITLE
Allow conversion of format without processing the date

### DIFF
--- a/moment-tokens.js
+++ b/moment-tokens.js
@@ -132,16 +132,24 @@
     moment.fn.__translateStrftimeToMoment = translateStrftimeToMoment;
     moment.fn.__translatePhpFormat = translatePhpFormat;
 
+    moment.fn.strftimeConvertFormat = function(format) {
+        return format.replace(/%?.|%%/g, translateStrftimeToMoment);
+    };
+
     moment.fn.strftime = function(format) {
         if (!strftimeFormats[format]) {
-            strftimeFormats[format] = format.replace(/%?.|%%/g, translateStrftimeToMoment);
+            strftimeFormats[format] = moment.strftimeConvertFormat(format);
         }
         return this.format(strftimeFormats[format]);
     };
 
+    moment.fn.phpConvertFormat = function(format) {
+        return format.replace(/\\?./g, translatePhpFormat);
+    };
+
     moment.fn.phpFormat = function(format) {
         if (!phpFormats[format]) {
-            phpFormats[format] = format.replace(/\\?./g, translatePhpFormat);
+            phpFormats[format] = moment.phpConvertFormat(format);
         }
         return this.format(phpFormats[format]);
     };


### PR DESCRIPTION
There are cases when the format is coming from PHP and we don't need the date formatted but we want to convert the format string from PHP style to Moment.js. This patch is simply externalizing the replacement of the format string. Now, in your app, you can do something like:

```
var formatFromPhp = 'Y-m-d';

// This will output "YYYY-MM-DD".
console.log(moment().phpConvertFormat(formatFromPhp));
```
