### PR TITLE
Allow conversion of format without processing the date

### DIFF
--- a/moment-tokens.js
+++ b/moment-tokens.js
@@ -60,6 +60,8 @@
                 return "H";
             case "e":
                 return "zz";
+            case "S":
+                return "o";
             default:
                 return item;
         }

--- a/moment-tokens.js
+++ b/moment-tokens.js
@@ -132,18 +132,26 @@
     moment.fn.__translateStrftimeToMoment = translateStrftimeToMoment;
     moment.fn.__translatePhpFormat = translatePhpFormat;
 
-    moment.fn.strftime = function(format) {
+    moment.fn.strftimeConvertFormat = function(format) {
         if (!strftimeFormats[format]) {
-            strftimeFormats[format] = format.replace(/%?.|%%/g, translateStrftimeToMoment);
+          strftimeFormats[format] = format.replace(/%?.|%%/g, translateStrftimeToMoment);
         }
-        return this.format(strftimeFormats[format]);
+        return strftimeFormats[format];
+    };
+
+    moment.fn.strftime = function(format) {
+        return this.format(moment.strftimeConvertFormat(format));
+    };
+
+    moment.fn.phpConvertFormat = function(format) {
+        if (!phpFormats[format]) {
+          phpFormats[format] = format.replace(/\\?./g, translatePhpFormat);
+        }
+        return phpFormats[format];
     };
 
     moment.fn.phpFormat = function(format) {
-        if (!phpFormats[format]) {
-            phpFormats[format] = format.replace(/\\?./g, translatePhpFormat);
-        }
-        return this.format(phpFormats[format]);
+        return this.format(moment.phpConvertFormat(format));
     };
 
     if (typeof module !== "undefined" && module !== null) {


### PR DESCRIPTION
There are cases when the format is coming from PHP and we don't need the date formatted but we want to convert the format string from PHP style to Moment.js. This patch is simply externalizing the replacement of the format string. Now, in your app, you can do something like:

```
var formatFromPhp = 'Y-m-d';

// This will output "YYYY-MM-DD".
console.log(moment().phpConvertFormat(formatFromPhp));
```
